### PR TITLE
Make WPML/Polylang plugin compatible with Accelerate theme

### DIFF
--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -1,0 +1,15 @@
+<wpml-config>
+	<admin-texts>
+		<key name="theme_mods_accelerate">
+			<key name="custom_logo" />
+			<key name="header_image" />
+			<key name="header_video" />
+			<key name="external_header_video" />
+			<key name="background_image" />
+		</key>
+		<key name="accelerate">
+			<key name="accelerate_read_more_text" />
+			<key name="accelerate_footer_editor" />
+		</key>
+	</admin-texts>
+</wpml-config>


### PR DESCRIPTION
# Description
- I've made WPML/Polylang plugin compatible with Accelerate theme.
# Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Changelog
 Enhancement - Make WPML/Polylang plugin compatible.
# Did you test this issue fix on all browsers?
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer
# Checklist:
- [x] My code follows the WPCS
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have made perform test that proves my fix is effective or that my feature works